### PR TITLE
Update fi.po

### DIFF
--- a/po/fi.po
+++ b/po/fi.po
@@ -20,7 +20,7 @@ msgstr ""
 msgid "Chess"
 msgstr "Šakki"
 #: Chess.qml:16
-msgid "Markings"
+msgid "Coordinates"
 msgstr "Merkinnät"
 #: Chess.qml:23
 msgid "Rotate"


### PR DESCRIPTION
Typo in the name of the branch. I don't seem to be able to get rid of this without merging.
